### PR TITLE
Remove ThemeToggle from App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { CheckCircle, Upload, RotateCcw, FileText, Minus, Plus, History, Trash2, Search } from 'lucide-react'
-import ThemeToggle from './ThemeToggle.jsx'
 import AdminEquipamentos from './AdminEquipamentos.jsx'
 import QuickSearch from './QuickSearch.jsx'
 import jsPDF from 'jspdf'
@@ -459,7 +458,6 @@ function App() {
                 Sistema de Checklist
               </h1>
             </div>
-            <ThemeToggle />
             <Button variant="outline" size="icon" onClick={() => setSearchOpen(true)}>
               <Search className="w-4 h-4" />
               <span className="sr-only">Buscar</span>


### PR DESCRIPTION
## Summary
- drop ThemeToggle import and usage from `App.jsx`
- keep lucide-react icon imports only

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e85943b20832ca0f47b8a1121a13f