### PR TITLE
Normalize cache comparison for equipment list

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",

--- a/src/AdminEquipamentos.jsx
+++ b/src/AdminEquipamentos.jsx
@@ -124,12 +124,11 @@ function AdminEquipamentos({ onEquipamentosChanged }) {
       const { data, error } = await supabase
         .from('equipamentos')
         .select('*')
-        .order('id')
 
       if (error) throw error
 
       const lista = data || []
-      setEquipamentos(lista)
+      setEquipamentos([...lista].sort((a, b) => a.id - b.id))
       return lista
     } catch (err) {
       console.error('Erro ao carregar equipamentos:', err)

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -1,11 +1,10 @@
 export function sincronizarCacheEquipamentos(cacheKey, listaAtual) {
   try {
     const cache = JSON.parse(localStorage.getItem(cacheKey) || '[]')
-    const cacheHash = JSON.stringify(cache)
-    const dataHash = JSON.stringify(listaAtual || [])
+    const data = listaAtual || []
 
-    if (cacheHash !== dataHash) {
-      localStorage.setItem(cacheKey, JSON.stringify(listaAtual))
+    if (!deepEqualById(cache, data)) {
+      localStorage.setItem(cacheKey, JSON.stringify(data))
       if (cache.length) alert('Lista de equipamentos atualizada')
     }
     return true
@@ -14,4 +13,26 @@ export function sincronizarCacheEquipamentos(cacheKey, listaAtual) {
     alert('Erro ao sincronizar cache de equipamentos. Verifique manualmente.')
     return false
   }
+}
+
+function deepEqualById(a, b) {
+  const sortById = (list) =>
+    [...list].sort((x, y) => {
+      if (x.id < y.id) return -1
+      if (x.id > y.id) return 1
+      return 0
+    })
+
+  const sortedA = sortById(a)
+  const sortedB = sortById(b)
+
+  if (sortedA.length !== sortedB.length) return false
+
+  for (let i = 0; i < sortedA.length; i++) {
+    const itemA = sortedA[i]
+    const itemB = sortedB[i]
+    if (JSON.stringify(itemA) !== JSON.stringify(itemB)) return false
+  }
+
+  return true
 }

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { sincronizarCacheEquipamentos } from '../src/lib/cache.js'
+
+test('reordering equipments does not update cache', () => {
+  const key = 'equipamentos-test'
+  const store = {}
+  let setCalls = 0
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      setCalls++
+      store[k] = String(v)
+    },
+  }
+  globalThis.alert = () => {}
+
+  const original = [
+    { id: 1, descricao: 'Eq1' },
+    { id: 2, descricao: 'Eq2' },
+  ]
+  store[key] = JSON.stringify(original)
+
+  const reordered = [
+    { id: 2, descricao: 'Eq2' },
+    { id: 1, descricao: 'Eq1' },
+  ]
+
+  sincronizarCacheEquipamentos(key, reordered)
+  assert.equal(setCalls, 0)
+})


### PR DESCRIPTION
## Summary
- sort equipment data by id and perform deep equality before caching
- load equipment unsorted and rely on normalized cache comparison
- add unit test ensuring reordering doesn't update cache

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e45efdd8832cb2b7e058dce49f99