### PR TITLE
Merge equipment data from JSON, cache, and Supabase

### DIFF
--- a/src/lib/fetchEquipamentos.js
+++ b/src/lib/fetchEquipamentos.js
@@ -1,0 +1,61 @@
+import equipamentosData from '../data/equipamentos.json' with { type: 'json' }
+
+export function mergeEquipamentos(base = [], local = [], remote = []) {
+  const map = new Map()
+  base.forEach(eq => {
+    map.set(eq.id, { ...eq })
+  })
+  local.forEach(eq => {
+    const existing = map.get(eq.id)
+    map.set(eq.id, existing ? { ...existing, ...eq } : { ...eq })
+  })
+  remote.forEach(eq => {
+    const existing = map.get(eq.id)
+    if (existing) {
+      map.set(eq.id, {
+        ...existing,
+        ...eq,
+        quantidadeLevando: existing.quantidadeLevando ?? eq.quantidadeLevando,
+        checado: existing.checado ?? eq.checado,
+      })
+    } else {
+      map.set(eq.id, { ...eq })
+    }
+  })
+  return Array.from(map.values()).sort((a, b) => a.id - b.id)
+}
+
+export async function fetchEquipamentos({ supabase, storage = globalThis.localStorage } = {}) {
+  const base = (equipamentosData || []).map(eq => ({
+    ...eq,
+    quantidadeLevando: eq.quantidade > 1 ? 0 : eq.quantidade,
+    checado: false,
+  }))
+
+  const local = JSON.parse(storage.getItem('equipamentos-checklist') || '[]')
+  let remote = []
+
+  if (supabase) {
+    try {
+      const { data, error } = await supabase
+        .from('equipamentos')
+        .select('*')
+        .order('id')
+
+      if (error) throw error
+
+      remote = (data || []).map(eq => ({
+        ...eq,
+        quantidadeLevando: eq.quantidade > 1 ? 0 : eq.quantidade,
+        checado: false,
+      }))
+    } catch (err) {
+      console.error('Erro ao carregar equipamentos do Supabase:', err)
+      alert('Erro ao carregar equipamentos do servidor. Verificando dados locais.')
+    }
+  }
+
+  const merged = mergeEquipamentos(base, local, remote)
+  storage.setItem('equipamentos-checklist', JSON.stringify(merged))
+  return merged
+}

--- a/test/offline.test.js
+++ b/test/offline.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchEquipamentos } from '../src/lib/fetchEquipamentos.js'
+
+const storageFactory = (initial = {}) => {
+  const store = { ...initial }
+  return {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v)
+    },
+    store,
+  }
+}
+
+test('merge base and local data when supabase offline', async () => {
+  const localItem = {
+    id: 999,
+    categoria: 'EXTRA',
+    quantidade: 1,
+    descricao: 'LOCAL ITEM',
+    estado: 'BOM',
+    observacoes: '',
+    quantidadeLevando: 1,
+    checado: true,
+  }
+
+  const storage = storageFactory({
+    'equipamentos-checklist': JSON.stringify([localItem]),
+  })
+
+  globalThis.alert = () => {}
+
+  const supabase = {
+    from() {
+      return {
+        select() {
+          return {
+            order() {
+              return Promise.resolve({ data: null, error: new Error('offline') })
+            },
+          }
+        },
+      }
+    },
+  }
+
+  const merged = await fetchEquipamentos({ supabase, storage })
+
+  assert(merged.some((eq) => eq.id === 1), 'includes base item')
+  assert(
+    merged.some((eq) => eq.id === 999 && eq.descricao === 'LOCAL ITEM'),
+    'includes local item'
+  )
+
+  const persisted = JSON.parse(storage.store['equipamentos-checklist'])
+  assert(persisted.some((eq) => eq.id === 1), 'persisted base item')
+  assert(persisted.some((eq) => eq.id === 999), 'persisted local item')
+})


### PR DESCRIPTION
## Summary
- load `equipamentos.json` as base data and merge with local cache and Supabase results
- centralize equipment fetch logic and store merged array in localStorage
- add tests verifying offline behavior keeps base and cached items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e8238fd0832ca49cb27dead34d8f