### PR TITLE
Ensure next equipment ID computed before add confirmation

### DIFF
--- a/src/AdminEquipamentos.jsx
+++ b/src/AdminEquipamentos.jsx
@@ -155,7 +155,10 @@ function AdminEquipamentos({ onEquipamentosChanged }) {
   }
 
   const handleAddSubmit = (values) => {
-    setAddValues(values)
+    const nextId = equipamentos.length
+      ? Math.max(...equipamentos.map((e) => e.id)) + 1
+      : 1
+    setAddValues({ ...values, id: nextId })
     setAddOpen(true)
   }
 


### PR DESCRIPTION
## Summary
- Calculate next equipment ID from current list when submitting new equipment
- Pass computed ID into `salvarNovo` by updating `addValues`

## Testing
- `pnpm lint`
- `pnpm test`
- `node -e` snippet verifying sequential IDs

------
https://chatgpt.com/codex/tasks/task_e_6899ef878728832ca6887470e6579c83