### PR TITLE
Show toast feedback when adding equipment

### DIFF
--- a/src/AdminEquipamentos.jsx
+++ b/src/AdminEquipamentos.jsx
@@ -46,6 +46,7 @@ import {
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { toast } from 'sonner'
 
 const equipamentoSchema = z.object({
   categoria: z.string().min(1, 'Informe a categoria'),
@@ -143,12 +144,15 @@ function AdminEquipamentos({ onEquipamentosChanged }) {
       return
     }
     const { error } = await supabase.from('equipamentos').insert([addValues])
-    if (!error) {
-      form.reset()
-      const lista = await carregarEquipamentos()
-      if (lista) sincronizarCacheEquipamentos(STORAGE_KEY, lista)
-      if (onEquipamentosChanged) onEquipamentosChanged()
+    if (error) {
+      toast.error('Erro ao adicionar equipamento')
+      return
     }
+    toast.success('Equipamento adicionado com sucesso')
+    form.reset()
+    const lista = await carregarEquipamentos()
+    if (lista) sincronizarCacheEquipamentos(STORAGE_KEY, lista)
+    if (onEquipamentosChanged) onEquipamentosChanged()
     setAddPwd('')
     setAddOpen(false)
     setAddValues(null)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { ThemeProvider } from './theme-provider.jsx'
+import { Toaster } from '@/components/ui/sonner.jsx'
 
 // --- CÓDIGO PARA VERIFICAR VERSÃO E LIMPAR DADOS ---
 
@@ -36,6 +37,7 @@ createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ThemeProvider>
       <App />
+      <Toaster />
     </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add toast notifications for adding equipment
- render toast container at app root

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f4f918f4832cae65c4c9769150ee